### PR TITLE
Enhancements to user interface and compatibility.

### DIFF
--- a/Medicat_Installer.sh
+++ b/Medicat_Installer.sh
@@ -1,10 +1,60 @@
-#!/bin/bash
-echo -e "WELCOME TO THE MEDICAT INSTALLER, PLEASE DO NOT RUN THIS AS ROOT\nThis Installer will attempt to Install Ventoy and Medicat\nTHIS IS IN BETA. PLEASE CONTACT MATT IN THE DISCORD FOR ALL ISSUES"
-echo "Updated for efficiency and cross-distro use by SkeletonMan"
-echo "Waiting for 10 seconds"
-sleep 10
+#!/usr/bin/env bash
 
+# Check if the terminal supports colour and set up variables if it does.
+NumColours=$(tput colors)
 
+if test -n "$NumColours" && test $NumColours -ge 8; then
+
+    clear="$(tput sgr0)"
+    blackN="$(tput setaf 0)";		blackN="$(tput bold setaf 0)"
+    redN="$(tput setaf 1)";			redB="$(tput bold setaf 1)"
+    greenN="$(tput setaf 2)";		greenB="$(tput bold setaf 2)"
+    yellowN="$(tput setaf 3)";		yellowB="$(tput bold setaf 3)"
+    blueN="$(tput setaf 4)";		blueB="$(tput bold setaf 4)"
+    magentaN="$(tput setaf 5)";		magentaB="$(tput bold setaf 5)"
+    cyanN="$(tput setaf 6)";		cyanB="$(tput bold setaf 6)"
+    whiteN="$(tput setaf 7)";		whiteB="$(tput bold setaf 7)"
+
+fi
+
+# Function to echo text using terminal colour codes ###########################
+function colEcho() {
+    echo -e "$1$2$clear"
+}
+
+# Function to wait for a user keypress.
+UserWait () {
+    read -n 1 -s -r -p "Press any key to continue"
+    echo -e "\r                         \r"
+}
+
+# Function to check we are not running with the elevated privileges. ##########
+function CheckNotElevated {
+
+    if (( "$EUID" == "0" )); then
+        colEcho $redB "ERROR: Running with elevated privileges - do not run using sudo\n"
+        exit 1
+    fi
+}
+
+# Main Code Start. ############################################################
+
+# Key variables used throughout the script to make maintenance easier.
+Medicat256Hash='a306331453897d2b20644ca9334bb0015b126b8647cecec8d9b2d300a0027ea4'
+Medicat7zFile="MediCat.USB.v21.12.7z"
+Medicat7zFull=''MediCat\ USB\ v21.12/MediCat.USB.v21.12.7z''
+
+clear
+colEcho $yellowB "WELCOME TO THE MEDICAT INSTALLER.\n"
+
+CheckNotElevated
+
+colEcho $cyanB "This Installer will install Ventoy and Medicat.\n"
+colEcho $yellowB "THIS IS IN BETA. PLEASE CONTACT MATT IN THE DISCORD FOR ALL ISSUES.\n"
+colEcho $cyanB "Updated for efficiency and cross-distro use by SkeletonMan.\n"
+colEcho $cyanB "Enhancements by Manganar.\n"
+
+# Set variables to support different distros.
 if grep -qs "ubuntu" /etc/os-release; then
 	os="ubuntu"
 	pkgmgr="apt"
@@ -21,7 +71,7 @@ elif [[ -e /etc/debian_version ]]; then
 	install_arg="install"
 	update_arg="update"
 elif [[ -e /etc/almalinux-release || -e /etc/rocky-release || -e /etc/centos-release ]]; then
-	echo "Fuck Red-Hat for putting source code behind paywalls."
+	colEcho $redB "Fuck Red-Hat for putting source code behind paywalls."
 	os="centos"
 	pkgmgr="yum"
 	install_arg="install"
@@ -36,114 +86,176 @@ elif [[ -e /etc/arch-release ]]; then
 	pkgmgr="pacman"
 	install_arg="-S --needed --noconfirm"
 	update_arg="-Syy"
+else
+	colEcho "ERROR: Distro not recognised - exiting..."
+	exit 1
 fi
-echo "Acquiring any dependencies"
+
+colEcho $cyanB "Operating System Identified:$whiteB $os \n"
+
+# Ensure dependencies are installed: wget, curl, 7z, mkntfs, aria2c
+colEcho $cyanB "Acquiring any dependencies..."
+
 sudo $pkgmgr $update_arg
 if ! [ $(which wget 2>/dev/null) ]; then
 	sudo $pkgmgr $install_arg wget
 fi
+
 if ! [ $(which curl 2>/dev/null) ]; then
 	sudo $pkgmgr $install_arg curl
 fi
+
 if ! [ $(which 7z 2>/dev/null) ]; then
 	if [[ -e /etc/arch-release ]]; then
 		sudo $pkgmgr $install_arg p7zip
 	elif [[ -e /etc/fedora-release  ]]; then
 		sudo $pkgmgr $install_arg p7zip-full p7zip-plugins
+	elif [ "$os" == "centos" ]; then
+		sudo $pkgmgr $install_arg p7zip p7zip-plugins
 	else
 		sudo $pkgmgr $install_arg p7zip-full
 	fi
 fi
+
 if ! [ $(sudo which mkntfs 2>/dev/null) ]; then 
-	sudo $pkgmgr $install_arg ntfs-3g
+	if [ "$os" == "centos" ]; then
+		sudo $pkgmgr $install_arg ntfsprogs
+	else
+		sudo $pkgmgr $install_arg ntfs-3g
+	fi
 fi
+
 if ! [ $(which aria2c 2>/dev/null) ]; then
 	sudo $pkgmgr $install_arg aria2
 fi
+
+# Identify latest Ventoy release.
 venver=$(curl -sL https://api.github.com/repos/ventoy/Ventoy/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
-rm latest
-echo -e "Attempting to download Ventoy Version: ${venver: -6}\n\n\n"
-wget https://github.com/ventoy/Ventoy/releases/download/v${venver: -6}/ventoy-${venver: -6}-linux.tar.gz -O ventoy.tar.gz
+
+# Download latest verion of Ventoy.
+colEcho $cyanB "\nDownloading Ventoy Version:$whiteB ${venver: -6}"
+wget -q --show-progress https://github.com/ventoy/Ventoy/releases/download/v${venver: -6}/ventoy-${venver: -6}-linux.tar.gz -O ventoy.tar.gz
+
+colEcho $cyanB "\nExtracting Ventoy..."
 tar -xf ventoy.tar.gz
-rm -rf ventoy.tar.gz ./ventoy/ventoy-${venver: -6}
-mv ventoy-${venver: -6} ventoy
-echo -e "\n\n\n\n\n\n"
-sha256hash='a306331453897d2b20644ca9334bb0015b126b8647cecec8d9b2d300a0027ea4'
-if [[ -f MediCat.USB.v21.12.7z ]]; then
-	location='MediCat.USB.v21.12.7z'
+
+colEcho $cyanB "Removing the extracted Ventory tar.gz file..."
+rm -rf ventoy.tar.gz
+
+# Remove the ./ventoy folder if it exists before renaming ventoy folder.
+if [ -d ./ventoy ]; then
+	colEcho $cyanB "Removing the previous ./ventoy folder..."
+	rm -rf ./ventoy/
 fi
-if ! [[ -f MediCat.USB.v21.12.7z ]]; then
-	if  [[ -f MediCat\ USB\ v21.12/MediCat.USB.v21.12.7z ]]; then
-		location=''MediCat\ USB\ v21.12/MediCat.USB.v21.12.7z''
+
+colEcho $cyanB "Renaming ventoy folder to remove the version number..."
+mv ventoy-${venver: -6} ventoy
+
+colEcho $cyanB "\nLocating the Medicat 7z file..."
+
+if [[ -f "$Medicat7zFile" ]]; then
+	location="$Medicat7zFile"
+else
+	if  [[ -f "$Medicat7zFull" ]]; then
+		location="$Medicat7zFull"
 	else
-	echo "Please enter location of MediCat.USB.v21.12.7z if it exists or just press enter to download it via torrent."
-	read location	
+		colEcho $cyanB "Please enter the location of$whiteB $Medicat7zFile$cyanB if it exists or just press enter to download it via bittorrent."
+		read location
 	fi
+
 	if [ -z "$location" ] ; then
-		echo "Starting to download torrent"
+		colEcho $cyanB "Starting to download torrent"
 		wget https://github.com/mon5termatt/medicat_installer/raw/main/download/MediCat_USB_v21.12.torrent -O medicat.torrent
 		aria2c --file-allocation=none --seed-time=0 medicat.torrent
-		location=''MediCat\ USB\ v21.12/MediCat.USB.v21.12.7z''
+		location="$Medicat7zFull"
 	fi
 fi
 
-echo -e "Checking Sha256 hash of MediCat.USB.v21.12.7z.."
-checksha256=$(sha256sum MediCat.USB.v21.12.7z | awk '{print $1}')
-if [[ checksha256 -ne $sha256hash ]]; then
-	echo -e "Your MediCat.USB.v21.12.7z SHA256 hash does not match!!!"
-	echo -e "Hash is $checksha256"
-	echo -e "Exiting for your safety!"
-	exit
+colEcho $cyanB "Medicat 7z file found:$whiteB $location"
+
+# Check the SHA256 hash of the Medicat zip file.
+colEcho $cyanB "Checking SHA256 hash of$whiteB $Medicat7zFile$cyanB..."
+
+checksha256=$(sha256sum "$location" | awk '{print $1}')
+
+if [[ "$checksha256" -ne "$Medicat256Hash" ]]; then
+	colEcho $redB "$Medicat7zFile SHA256 hash does not match."
+	colEcho $redB "File may be corrupted or compromised."
+	colEcho $cyanB "Hash is$whiteB $checksha256"
+	colEcho $cyanB "Exiting..."
+	exit 1
 else
-	echo -e "Your MediCat.USB.v21.12.7z sha256 hash matches!"
-	echo -e "Hash is $checksha256"
-	echo -e "We are safe to proceed"
+	colEcho $greenB "$Medicat7zFile SHA256 hash matches."
+	colEcho $cyanB "Hash is$whiteB $checksha256"
+	colEcho $cyanB "Safe to proceed..."
 fi
 
+# Advise user to connect and select the required USB device.
+colEcho $yellowB "\nPlease Plug your USB in now if it is not already connected..."
+UserWait
 
-echo -e "\n\n\n"
-echo "Please Plug your USB in now if it is not already"
-echo "Waiting 15 seconds..."
-sleep 15
-echo "Please Find the ID of your USB below"
-echo -e "\n\n"
-lsblk | awk '{print $1,$4}'
-echo "Enter the Letter of the USB drive below NOT INCLUDING /dev/ OR the Number After"
-echo "for example enter sda or sdb"
+colEcho $yellowB "Please Find the ID of your USB below:"
+
+lsblk --scsi --nodeps --output "NAME,SIZE,MOUNTPOINTS"
+
+colEcho $yellowB "Enter the device for the USB drive NOT INCLUDING /dev/ OR the Number After."
+colEcho $yellowB "for example enter sda or sdb"
 read letter
+
 drive=/dev/$letter
 drive2="$drive""1"
 checkingconfirm=""
+
 while [[ "$checkingconfirm" != [NnYy]* ]]; do
 	read -e -p "You want to install Ventoy and Medicat to $drive / $drive2? (Y/N) " checkingconfirm
 	if [[ "$checkingconfirm" == [Nn]* ]]; then
-        exit
+		colEcho $yellowB "Installation Cancelled."
+		exit
 	elif [[ "$checkingconfirm" == [Yy]* ]]; then
-		echo "Okay! Will continue in 5 seconds!"
+		colEcho $cyanB "Installation confirmed and will commence in 5 seconds..."
 		sleep 5
 	else
-		echo "Invalid input!"
+		colEcho $redB "Invalid input. Please enter 'Y' or 'N'."
 	fi
 done
 
+colEcho $cyanB "Installing Ventoy on$whiteB $drive"
 sudo sh ./ventoy/Ventoy2Disk.sh -I $drive
-umount $drive
+if [ "$?" != "0" ]; then
+	colEcho $redB "ERROR: Unable to install Ventoy. Exiting..."
+	exit 1
+fi
+
+colEcho $cyanB "Unmounting drive$whiteB $drive"
+sudo umount $drive
+
+colEcho $cyanB "Creating Medicat NTFS file system on drive$whiteB $drive2"
 sudo mkntfs --fast --label Medicat $drive2
+
+# Create a mountpoint folder for the Medicat NTFS volume
 if ! [[ -d MedicatUSB/ ]] ; then
+	colEcho $cyanB "Creating a mountpoint for the Medicat NTFS volume..."
 	mkdir MedicatUSB
 fi
+
+colEcho $cyanB "Mounting Medicat NTFS volume..."
 sudo mount $drive2 ./MedicatUSB
+
+colEcho $cyanB "Extracting Medicat to NTFS volume..."
 7z x -O./MedicatUSB "$location"
-echo "MedicatUSB has been created!"
+
+colEcho $cyanB "MedicatUSB has been created."
+
 unmountcheck=""
 while [[ "$unmountcheck" != [NnYy]* ]]; do
 	read -e -p "Would you like to unmount ./MedicatUSB? (Y/N) " unmountcheck
 	if [[ $unmountcheck == [Yy]* ]]; then
-		echo "MedicatUSB will be unmounted!"
+		colEcho $cyanB "Unmounting MedicatUSB..."
 		sudo umount ./MedicatUSB
+		colEcho $cyanB "Unmounted."
 	elif [[ $unmountcheck == [Nn]* ]]; then
-		echo "MedicatUSB will not be unmounted!"
+		colEcho $cyanB "MedicatUSB will not be unmounted."
 	else
-		echo "Invalid input!"
+		colEcho $redB "Invalid input. Please enter 'Y' or 'N'."
 	fi
 done


### PR DESCRIPTION
- Changed shebang line to use /usr/bin/env to identify bash
- Added code to support terminal colours, including a convenience function to echo a line in a specific colour.
- Added a function to wait for a user keypress.
- Added a function to confirm not running as root.
- Added an else clause to the distro detection to exit if the distro is not recognised.
- Change wget to show progress.
- Changed process to remove the ./ventoy folder, checking if it exists first.
- Moved the hash code and hard coded filenames to variables at the start of the script for easier maintenance (not completely implemented yet).
- Changed to wait for a keypress when prompting for USB drive to be plugged in.
- Changed lsblk to simplify the list shown to the user (further updates to use whiptail in progress).
- Check for non-zero return from the Ventoy installation and advise user and exit if so (note, this is fragile and relies on the non-zero return code from the various Ventoy scripts being passed through which is unlikely.
- Modified to install correct packages on CentOS for 7zip and mkntfs.
- Added more progress messages.
- Successfully tested on: Pop!_OS; Debian 12; CentOS Stream 9; Manjaro; Fedora 37; Ubuntu 23.10.
- To do: FreeBSD not working as it doesn't support lsblk.