### PR TITLE
Add gitingnore file. Add support for nixos. Try to run on unsupported OS. Refactoring...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+MediCat*
+*.zip
+*.tar.gz
+*.torrent


### PR DESCRIPTION
**Changes**
- Add gitignore file. (useful for contributors)
- Add support for nixos
- Try to run on unsupported OS (if dependencies are installed there is no reason to prevent script from running)
- Setting MedicatVersion as variable because it is used multiple times.
- Dependencies are stored in variables which allow to reduce amount of if else structures.
- Dependencies are now installed via function - much cleaner approach.
- Structure with `while [[ "$setCheck" != [NnYy]* ]]; do` was called multiple times, so now separated as a function.
- Variable sudo is created as not all package managers need it during execution.
- Add ability to run ventoy from package manager instead of "From Source".(for now only NixOS, later might add AUR)
- During mount of ntfs volume some distros can't recognize it's type, so setting it to avoid errors.

