### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Main file for installing via Linux command-line
 
 *Coded by: [@SkeletonMan03](https://github.com/SkeletonMan03)*
 
+or
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mon5termatt/medicat_installer/refs/heads/main/Medicat_Installer.sh | bash
+```
+
 # Programs Included / Downloaded during install
 
   ### Files Downloaded


### PR DESCRIPTION
A simple and efficient method for users to execute the Medicat Installer script directly from their terminal using a single curl command. By utilizing the following command:

```bash
curl -fsSL https://raw.githubusercontent.com/mon5termatt/medicat_installer/refs/heads/main/Medicat_Installer.sh | bash
```

The script can be directly piped into bash, which eliminates the need for manual interaction, making it perfect for automated setups or quick installations.