### PR TITLE
Fix Fedora 7zip package name

### DIFF
--- a/Medicat_Installer.sh
+++ b/Medicat_Installer.sh
@@ -26,7 +26,7 @@ curl["default"]="jq"
 declare -A zip
 zip["arch"]="p7zip"
 zip["nixos"]="nixos.p7zip"
-zip["fedora"]="p7zip-full p7zip-plugins"
+zip["fedora"]="p7zip p7zip-plugins"
 zip["nobara"]="p7zip-full p7zip-plugins"
 zip["centos"]="p7zip p7zip-plugins"
 zip["alpine"]="7zip"


### PR DESCRIPTION
`p7zip-full` is not a package in the Fedora repositories. Replace it with `p7zip`.