### PR TITLE
Fix p7zip dep for fedora

### DIFF
--- a/Medicat_Installer.sh
+++ b/Medicat_Installer.sh
@@ -22,7 +22,7 @@ wget["default"]="wget"
 declare -A zip
 zip["arch"]="p7zip"
 zip["nixos"]="nixos.p7zip"
-zip["fedora"]="p7zip-full p7zip-plugins"
+zip["fedora"]="p7zip p7zip-plugins"
 zip["nobara"]="p7zip-full p7zip-plugins"
 zip["centos"]="p7zip p7zip-plugins"
 zip["alpine"]="7zip"


### PR DESCRIPTION
Fixing p7zip for fedora because p7zip-full is not in fedora packages.

Related to : https://canary.discord.com/channels/829469886681972816/1384906572450238476 in discord.

Note : As mentionned by user Nicki, 7z? but thinking 7zip is in the epel packages so not in vanilla install.