### PR TITLE
New link for tcbl

### DIFF
--- a/download/cdn.bat
+++ b/download/cdn.bat
@@ -10,7 +10,7 @@ set "REFERER=https://installer.medicatusb.com"
 :: Server URLs
 set "SERVER1=https://files.medicatusb.com/files/v21.12/%FILE_NAME%"
 set "SERVER2=https://files.dog/OD%%20Rips/MediCat/v21.12/%FILE_NAME%"
-set "SERVER3=https://cdn.tcbl.dev/medicat/%FILE_NAME%"
+set "SERVER3=https://cat.tcbl.dev/%FILE_NAME%"
 
 :check
 cls


### PR DESCRIPTION
Updating tcbl link according to the https://medicat.tcbl.dev/ and old link not working anymore. (no dns resolution)..