### PR TITLE
Fix MedicatFileChecker.ps1: missing TranslationHelper.ps1 + TLS 1.2

### DIFF
--- a/MedicatFileChecker.ps1
+++ b/MedicatFileChecker.ps1
@@ -22,7 +22,7 @@ Add-Type -AssemblyName System.Drawing
 
 # Load translation helper
 $translationHelperPath = Join-Path $PSScriptRoot "TranslationHelper.ps1"
-if (Test-Path $translationHelperPath) {
+if (Test-Path -LiteralPath $translationHelperPath) {
     . $translationHelperPath
     # Detect system language and load translations
     $culture = [System.Globalization.CultureInfo]::CurrentCulture
@@ -399,8 +399,8 @@ function Invoke-Download {
         $webClient = New-Object System.Net.WebClient
         $webClient.DownloadFile($Url, $OutputPath)
         
-        if (Test-Path $OutputPath) {
-            $actualSize = (Get-Item $OutputPath).Length
+        if (Test-Path -LiteralPath $OutputPath) {
+            $actualSize = (Get-Item -LiteralPath $OutputPath).Length
             Write-Log "Downloaded: $OutputPath ($actualSize bytes)"
             
             if ($ExpectedSize -and $actualSize -ne $ExpectedSize) {
@@ -490,10 +490,10 @@ function Start-FileCheck {
                     }
                     
                     # Check if file exists
-                    if (Test-Path $filePath) {
+                    if (Test-Path -LiteralPath $filePath) {
                         # Calculate MD5 hash using PowerShell
                         try {
-                            $actualHash = (Get-FileHash -Path $filePath -Algorithm MD5).Hash.ToLower()
+                            $actualHash = (Get-FileHash -LiteralPath $filePath -Algorithm MD5).Hash.ToLower()
                             
                             if ($actualHash -eq $expectedHash) {
                                 $verifiedFiles++
@@ -556,8 +556,8 @@ function Start-FileCheck {
             }
             
             # Clean up MD5 file
-            if (Test-Path $md5File) {
-                Remove-Item $md5File -Force
+            if (Test-Path -LiteralPath $md5File) {
+                Remove-Item -LiteralPath $md5File -Force
                 Write-Log "Cleaned up temporary MD5 file"
             }
         } else {
@@ -602,14 +602,14 @@ function Start-ReExtractFiles {
         # If not in PATH, check bin folder
         if (-not $sevenZipPath) {
             $binPath = ".\bin\7z.exe"
-            if (Test-Path $binPath) {
+            if (Test-Path -LiteralPath $binPath) {
                 $sevenZipPath = (Resolve-Path $binPath).Path
                 Write-Log "Found 7z.exe in bin folder: $sevenZipPath"
             }
         }
         
         # If still not found, error out
-        if (-not $sevenZipPath -or -not (Test-Path $sevenZipPath)) {
+        if (-not $sevenZipPath -or -not (Test-Path -LiteralPath $sevenZipPath)) {
             Write-Log "ERROR: 7z.exe not found in PATH or bin folder"
             Show-MessageBox -Message (Get-MessageTranslation -Key "7zip_not_found") -Title (Get-TitleTranslation -Key "7zip_not_found") -Icon "Error"
             return $false
@@ -619,7 +619,7 @@ function Start-ReExtractFiles {
         $archiveFile = Join-Path $PWD "MediCat.USB.v$script:MediCatVersion.7z"
         
         # If not found in current directory, prompt user to select the file
-        if (-not (Test-Path $archiveFile)) {
+        if (-not (Test-Path -LiteralPath $archiveFile)) {
             Write-Log "Archive not found in current directory, prompting user to select file..."
             Update-Status (Get-StatusTranslation -Key "select_archive")
             
@@ -639,7 +639,7 @@ function Start-ReExtractFiles {
             }
         }
         
-        if (-not (Test-Path $archiveFile)) {
+        if (-not (Test-Path -LiteralPath $archiveFile)) {
             Write-Log "ERROR: Source archive not found: $archiveFile"
             Show-MessageBox -Message (Get-MessageTranslation -Key "archive_not_found" -FormatArgs $archiveFile) -Title (Get-TitleTranslation -Key "archive_not_found") -Icon "Error"
             return $false
@@ -709,7 +709,7 @@ function Start-ReExtractFiles {
                 $failedExtract = @()
                 foreach ($file in $normalizedFiles) {
                     $fullPath = Join-Path $outputDir $file
-                    if (Test-Path $fullPath) {
+                    if (Test-Path -LiteralPath $fullPath) {
                         $extractedCount++
                     } else {
                         $failedExtract += $file
@@ -732,8 +732,8 @@ function Start-ReExtractFiles {
             $extractedCount = 0
         } finally {
             # Clean up file list if it still exists
-            if (Test-Path $fileListPath) {
-                Remove-Item $fileListPath -ErrorAction SilentlyContinue
+            if (Test-Path -LiteralPath $fileListPath) {
+                Remove-Item -LiteralPath $fileListPath -ErrorAction SilentlyContinue
             }
         }
         

--- a/MedicatFileChecker.ps1
+++ b/MedicatFileChecker.ps1
@@ -1,6 +1,10 @@
 # MediCat File Checker - Standalone File Verification Tool
 # PowerShell-based file checker with MD5 verification and re-extraction support
 
+# Some systems don't negotiate TLS 1.2 by default, which raw.githubusercontent.com requires,
+# causing WebClient downloads (the MD5 manifest) to fail with a generic WebException.
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 # Ensure we're in the correct directory (script directory)
 $scriptPath = $MyInvocation.MyCommand.Path
 if (-not $scriptPath) {

--- a/TranslationHelper.ps1
+++ b/TranslationHelper.ps1
@@ -1,0 +1,67 @@
+# Loads translations.json and exposes Get-*Translation lookup functions.
+# Referenced by MedicatFileChecker.ps1 via dot-sourcing; previously missing from the repo,
+# which caused every UI label/status/message to fall back to a raw "[key]" placeholder
+# and broke the drive dropdown's per-item formatting entirely.
+
+$script:TranslationRoot = $null
+$script:TranslationLanguage = "en"
+
+function Load-Translations {
+    param(
+        [string]$Language = "en"
+    )
+
+    $translationsPath = Join-Path $PSScriptRoot "translations.json"
+    if (-not (Test-Path $translationsPath)) {
+        Write-Warning "translations.json not found at $translationsPath. Falling back to raw keys."
+        return $false
+    }
+
+    $allTranslations = Get-Content $translationsPath -Raw | ConvertFrom-Json
+    $script:TranslationLanguage = if ($allTranslations.$Language) { $Language } else { "en" }
+    $script:TranslationRoot = $allTranslations.$($script:TranslationLanguage)
+    return $true
+}
+
+function Get-TranslationValue {
+    param(
+        [string]$Category,
+        [string]$Key,
+        $FormatArgs = @()
+    )
+
+    $text = $null
+    if ($script:TranslationRoot -and $script:TranslationRoot.$Category.$Key) {
+        $text = $script:TranslationRoot.$Category.$Key
+    }
+
+    if (-not $text) {
+        return "[$Key]"
+    }
+
+    if ($FormatArgs -and @($FormatArgs).Count -gt 0) {
+        return ($text -f @($FormatArgs))
+    }
+
+    return $text
+}
+
+function Get-UITranslation {
+    param([string]$Key, $FormatArgs = @())
+    return Get-TranslationValue -Category "ui" -Key $Key -FormatArgs $FormatArgs
+}
+
+function Get-StatusTranslation {
+    param([string]$Key, $FormatArgs = @())
+    return Get-TranslationValue -Category "status" -Key $Key -FormatArgs $FormatArgs
+}
+
+function Get-MessageTranslation {
+    param([string]$Key, $FormatArgs = @())
+    return Get-TranslationValue -Category "messages" -Key $Key -FormatArgs $FormatArgs
+}
+
+function Get-TitleTranslation {
+    param([string]$Key, $FormatArgs = @())
+    return Get-TranslationValue -Category "titles" -Key $Key -FormatArgs $FormatArgs
+}

--- a/TranslationHelper.ps1
+++ b/TranslationHelper.ps1
@@ -12,12 +12,12 @@ function Load-Translations {
     )
 
     $translationsPath = Join-Path $PSScriptRoot "translations.json"
-    if (-not (Test-Path $translationsPath)) {
+    if (-not (Test-Path -LiteralPath $translationsPath)) {
         Write-Warning "translations.json not found at $translationsPath. Falling back to raw keys."
         return $false
     }
 
-    $allTranslations = Get-Content $translationsPath -Raw | ConvertFrom-Json
+    $allTranslations = Get-Content -LiteralPath $translationsPath -Raw | ConvertFrom-Json
     $script:TranslationLanguage = if ($allTranslations.$Language) { $Language } else { "en" }
     $script:TranslationRoot = $allTranslations.$($script:TranslationLanguage)
     return $true


### PR DESCRIPTION
## Summary
- `MedicatFileChecker.ps1` dot-sources `TranslationHelper.ps1`, but that file doesn't exist anywhere in this repo. This makes every UI label/status fall back to a raw `[key]` placeholder, and breaks the drive-selector dropdown specifically — its `drive_format` string is rendered without argument substitution, so every entry in the dropdown looks identical and the actual target drive can't be identified/selected.
- Adds `TranslationHelper.ps1` implementing `Load-Translations` + the `Get-UITranslation`/`Get-StatusTranslation`/`Get-MessageTranslation`/`Get-TitleTranslation` lookups against the existing `translations.json`, with proper `-f` format-string substitution.
- Sets `SecurityProtocol` to `Tls12` before the MD5 manifest download — `WebClient` doesn't negotiate TLS 1.2 by default on all systems, and `raw.githubusercontent.com` requires it, so the manifest download fails outright without this on some machines.

## Test plan
- [x] Parsed both files with `[System.Management.Automation.Language.Parser]::ParseFile` — no syntax errors
- [x] Dot-sourced `TranslationHelper.ps1` standalone and confirmed `Get-UITranslation`/`Get-StatusTranslation` return real strings with arguments correctly substituted (e.g. `drive_format` → `E: (USB) - 31GB free of 58GB`)
- [x] Ran the patched `MedicatFileChecker.ps1` end-to-end against a real MediCat USB install — drive dropdown populated correctly, manifest downloaded successfully, file verification completed

Found and fixed while using this tool to check an existing MediCat/Ventoy USB install. Co-authored with Claude Code (Anthropic).