### PR TITLE
Add .gitattributes to prevent CRLF in .sh installer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+


### PR DESCRIPTION
I just downloaded the Linux installer Medicat_Installer.sh from the website, but it came with CRLF line endings so I couldn't run it out of the box. This PR adds a .gitattributes file that specifies that .sh files should always have LF line endings, regardless of the platform they are pulled to.